### PR TITLE
🔧 add IPC::Run3 to PREREQ_PM and configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cpan"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,8 @@ WriteMakefile(
 	NAME         => 'Daybo::Twitch::Retag',
 
         PREREQ_PM => {
-                'Moose'    => 0,
+                'IPC::Run3' => 0,
+                'Moose'     => 0,
 	}, BUILD_REQUIRES => {
 		'Sys::CPU' => 0,
 		#'Moose'           => 0,


### PR DESCRIPTION
IPC::Run3 was used in Retag.pm but not declared as a runtime dependency in Makefile.PL. Also adds .github/dependabot.yml to enable weekly CPAN dependency monitoring via GitHub's dependency graph.